### PR TITLE
avoid no-color-bug when more than 21 observables are shown

### DIFF
--- a/royweb/static/js/tools.js
+++ b/royweb/static/js/tools.js
@@ -43,7 +43,8 @@ var roy = {
                           "#4F373E", "#9E6613", "#A27B90", "#E5689F",
                           "#01687A", "#BDA1DA", "#D0B53B", "#59CEAB",
                           "#601D3C", "#4D419A"];
-            return colors[i];
+
+            return colors[i % colors.length];
         }
     },
     ui: {


### PR DESCRIPTION
It is just a patch (my first time editing a javascript code) to ensure that the page does not go out-of-colors, but it recycles the same colors for newest plots, so a colour clash can happen in multi-parameter plots. It is worth to consider using a colour generator, like chroma.js